### PR TITLE
Bug fix in falsy-values-array.md

### DIFF
--- a/tips/falsy-values-array.md
+++ b/tips/falsy-values-array.md
@@ -6,4 +6,4 @@ twitter: "telmo"
 
 const array = [false, 'NextJS', undefined, 'React', null]
 
-arr.filter(Boolean) // ['NextJS', 'React']
+array.filter(Boolean) // ['NextJS', 'React']


### PR DESCRIPTION
Minor bug fix in a tip. Using the declared variable `array` instead of `arr`.